### PR TITLE
Define `MuchDecimal` mixin

### DIFF
--- a/lib/much-decimal.rb
+++ b/lib/much-decimal.rb
@@ -1,5 +1,48 @@
-require "much-decimal/version"
+require 'much-plugin'
+
+require 'much-decimal/version'
 
 module MuchDecimal
+  include MuchPlugin
+
+  DEFAULT_PRECISION = 2.freeze
+
+  def self.integer_to_decimal(integer, precision)
+    if integer.respond_to?(:to_i) && !integer.to_s.empty?
+      base_10_modifier = (10.0 ** precision)
+      integer.to_i / base_10_modifier
+    end
+  end
+
+  def self.decimal_to_integer(decimal, precision)
+    if decimal.respond_to?(:to_f) && !decimal.to_s.empty?
+      base_10_modifier = (10.0 ** precision)
+      (decimal.to_f * base_10_modifier).round.to_i
+    end
+  end
+
+  plugin_included do
+    extend ClassMethods
+  end
+
+  module ClassMethods
+
+    def decimal_as_integer(attribute, options = nil)
+      options ||= {}
+      source    = options[:source] || "#{attribute}_as_integer"
+      precision = (options[:precision] || DEFAULT_PRECISION).to_i
+
+      define_method(attribute) do
+        integer = self.send(source)
+        MuchDecimal.integer_to_decimal(integer, precision)
+      end
+
+      define_method("#{attribute}=") do |decimal|
+        integer = MuchDecimal.decimal_to_integer(decimal, precision)
+        self.send("#{source}=", integer)
+      end
+    end
+
+  end
 
 end

--- a/much-decimal.gemspec
+++ b/much-decimal.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_development_dependency("assert", ["~> 2.16.1"])
-  # TODO: gem.add_dependency("gem-name", ["~> 0.0.0"])
+
+  gem.add_dependency('much-plugin', ["~> 0.1.1"])
 
 end

--- a/test/unit/much_decimal_tests.rb
+++ b/test/unit/much_decimal_tests.rb
@@ -1,0 +1,190 @@
+require 'assert'
+require 'much-decimal'
+
+module MuchDecimal
+
+  class UnitTests < Assert::Context
+    desc "MuchDecimal"
+    setup do
+      @module = MuchDecimal
+    end
+    subject{ @module }
+
+    should have_imeths :integer_to_decimal, :decimal_to_integer
+
+    should "use much-plugin" do
+      assert_includes MuchPlugin, subject
+    end
+
+    should "know its default precision" do
+      assert_equal 2, DEFAULT_PRECISION
+    end
+
+    should "know how to convert an integer to a decimal" do
+      integer          = Factory.integer
+      precision        = Factory.integer(10)
+      base_10_modifier = (10.0 ** precision)
+
+      exp = integer / base_10_modifier
+      assert_equal exp, subject.integer_to_decimal(integer,      precision)
+      assert_equal exp, subject.integer_to_decimal(integer.to_s, precision)
+
+      invalid_value = [nil, '', true, false].sample
+      assert_nil subject.integer_to_decimal(invalid_value, precision)
+    end
+
+    should "know how to convert a decimal to an integer" do
+      decimal          = Factory.float
+      precision        = Factory.integer(10)
+      base_10_modifier = (10.0 ** precision)
+
+      exp = (decimal * base_10_modifier).round.to_i
+      assert_equal exp, subject.decimal_to_integer(decimal,      precision)
+      assert_equal exp, subject.decimal_to_integer(decimal.to_s, precision)
+
+      invalid_value = [nil, '', true, false].sample
+      assert_nil subject.decimal_to_integer(invalid_value, precision)
+    end
+
+  end
+
+  class MixinTests < UnitTests
+    desc "when mixed in"
+    setup do
+      @class = Class.new do
+        include MuchDecimal
+        attr_accessor :seconds_as_integer, :integer_seconds
+      end
+    end
+    subject{ @class }
+
+    should have_imeths :decimal_as_integer
+
+    should "add a decimal-as-integer accessor using `decimal_as_integer`" do
+      subject.decimal_as_integer :seconds
+
+      instance = subject.new
+      assert_respond_to :seconds,  instance
+      assert_respond_to :seconds=, instance
+
+      decimal = Factory.float
+      integer = Factory.integer
+
+      instance.seconds = decimal
+      exp = @module.decimal_to_integer(decimal, DEFAULT_PRECISION)
+      assert_equal exp, instance.seconds_as_integer
+
+      instance.seconds_as_integer = integer
+      exp = @module.integer_to_decimal(integer, DEFAULT_PRECISION)
+      assert_equal exp, instance.seconds
+    end
+
+    should "allow specifying custom options using `decimal_as_integer`" do
+      source    = :integer_seconds
+      precision = Factory.integer(5)
+      subject.decimal_as_integer :seconds, {
+        :source    => source,
+        :precision => precision
+      }
+
+      instance = subject.new
+      assert_respond_to :seconds,  instance
+      assert_respond_to :seconds=, instance
+
+      decimal = Factory.float
+      integer = Factory.integer
+
+      instance.seconds = decimal
+      exp = @module.decimal_to_integer(decimal, precision)
+      assert_equal exp, instance.send(source)
+
+      instance.send("#{source}=", integer)
+      exp = @module.integer_to_decimal(integer, precision)
+      assert_equal exp, instance.seconds
+    end
+
+  end
+
+  class EdgeCaseTests < UnitTests
+    desc "edge cases"
+    setup do
+      @class = Class.new do
+        include MuchDecimal
+
+        attr_accessor :ten_thousandth_seconds
+
+        decimal_as_integer(:seconds, {
+          :source    => :ten_thousandth_seconds,
+          :precision => 4
+        })
+      end
+      @instance = @class.new
+    end
+    subject{ @instance }
+
+    should "allow writing and reading `nil` values" do
+      assert_nil subject.ten_thousandth_seconds
+      assert_nil subject.seconds
+
+      subject.seconds = 1.2345
+      assert_equal 12345,  subject.ten_thousandth_seconds
+      assert_equal 1.2345, subject.seconds
+
+      assert_nothing_raised{ subject.seconds = nil }
+      assert_nil subject.seconds
+      assert_nil subject.ten_thousandth_seconds
+    end
+
+    should "write empty string values as `nil` values" do
+      subject.seconds = 1.2345
+      assert_not_nil subject.ten_thousandth_seconds
+      assert_not_nil subject.seconds
+
+      assert_nothing_raised{ subject.seconds = '' }
+      assert_nil subject.seconds
+      assert_nil subject.ten_thousandth_seconds
+    end
+
+    should "write values that can't be converted as `nil` values" do
+      subject.seconds = 1.2345
+      assert_not_nil subject.ten_thousandth_seconds
+      assert_not_nil subject.seconds
+
+      assert_nothing_raised{ subject.seconds = true }
+      assert_nil subject.seconds
+      assert_nil subject.ten_thousandth_seconds
+    end
+
+    should "handle decimals with less significant digits" do
+      subject.seconds = 1.12
+      assert_equal 11200, subject.ten_thousandth_seconds
+      assert_equal 1.12,  subject.seconds
+    end
+
+    should "handle integers" do
+      subject.seconds = 5
+      assert_equal 50000, subject.ten_thousandth_seconds
+      assert_equal 5.0,   subject.seconds
+    end
+
+    should "handle decimals that are less than 1" do
+      subject.seconds = 0.0001
+      assert_equal 1,      subject.ten_thousandth_seconds
+      assert_equal 0.0001, subject.seconds
+    end
+
+    should "handle decimals with too many significant digits by rounding" do
+      subject.seconds = 1.00005
+      assert_equal 10001,  subject.ten_thousandth_seconds
+      assert_equal 1.0001, subject.seconds
+    end
+
+    should "handle repeating decimals" do
+      subject.seconds = 1 / 3.0
+      assert_equal 3333,   subject.ten_thousandth_seconds
+      assert_equal 0.3333, subject.seconds
+    end
+
+  end
+
+end


### PR DESCRIPTION
This makes the `MuchDecimal` a mixin that can be used to define
attributes that are decimals stored as integers. This allows easily
setting up attributes that are decimals but store their values as
integers. The decimals can be used for presentation/display while
the integer can be used for math operations. This is particularly
useful when working with currency.

This brings in much-plugin and makes the main module `MuchDecimal`
a plugin. The plugin simply adds a class method
`decimal_as_integer` that allows setting up decimal as integer
attributes. The class method takes an attribute name and a set of
options. The source attribute and a precision are the possible
options. The source attributes specifies the accessor that the
integer will be written to. The precision is the number of decimal
places or how precise you want the integer to be. Both of these are
defaulted if they aren't provided.

The class method defines a reader and writer. The readers reads
from the source accessor expecting an integer and converting it to
its decimal using the precision. The writer expects a decimal and
converts it to an integer using the precision and writes it to the
source accessor. Both of these handle `nil` and non numeric values
appropriately.

Finally, this pulls the conversion logic, decimal to integer and
integer to decimal, into singleton methods on the main module.
This allows their logic to be used directly. This is particularly
useful for testing that an attribute is using much-decimal.

@kellyredding - Ready for review. I coped the edge case tests as-is from where we originally implemented this.
