### PR TITLE
Add `TestHelpers`

### DIFF
--- a/lib/much-decimal.rb
+++ b/lib/much-decimal.rb
@@ -45,4 +45,33 @@ module MuchDecimal
 
   end
 
+  module TestHelpers
+    include MuchPlugin
+
+    plugin_included do
+      include InstanceMethods
+
+      require 'assert/factory'
+    end
+
+    module InstanceMethods
+
+      def assert_decimal_as_integer(subject, attribute, options = nil)
+        options ||= {}
+        source    = options[:source] || "#{attribute}_as_integer"
+        precision = (options[:precision] || DEFAULT_PRECISION).to_i
+
+        value = Assert::Factory.float
+        subject.send("#{attribute}=", value)
+
+        exp = MuchDecimal.decimal_to_integer(value, precision)
+        assert_equal exp, subject.send(source)
+        exp = MuchDecimal.integer_to_decimal(exp, precision)
+        assert_equal exp, subject.send(attribute)
+      end
+
+    end
+
+  end
+
 end

--- a/test/unit/much_decimal_tests.rb
+++ b/test/unit/much_decimal_tests.rb
@@ -48,8 +48,7 @@ module MuchDecimal
 
   end
 
-  class MixinTests < UnitTests
-    desc "when mixed in"
+  class MixinSetupTests < UnitTests
     setup do
       @class = Class.new do
         include MuchDecimal
@@ -57,6 +56,11 @@ module MuchDecimal
       end
     end
     subject{ @class }
+
+  end
+
+  class MixinTests < MixinSetupTests
+    desc "when mixed in"
 
     should have_imeths :decimal_as_integer
 
@@ -183,6 +187,32 @@ module MuchDecimal
       subject.seconds = 1 / 3.0
       assert_equal 3333,   subject.ten_thousandth_seconds
       assert_equal 0.3333, subject.seconds
+    end
+
+  end
+
+  class TestHelpersTests < MixinSetupTests
+    include MuchDecimal::TestHelpers
+
+    desc "TestHelpers"
+    setup do
+      @class.decimal_as_integer :seconds
+      @custom_precision = Factory.integer(10)
+      @class.decimal_as_integer :other_seconds, {
+        :source    => :integer_seconds,
+        :precision => @custom_precision
+      }
+
+      @instance = @class.new
+    end
+    subject{ @instance }
+
+    should "provide helpers for testing that a class has json fields" do
+      assert_decimal_as_integer subject, :seconds
+      assert_decimal_as_integer subject, :other_seconds, {
+        :source    => :integer_seconds,
+        :precision => @custom_precision
+      }
     end
 
   end


### PR DESCRIPTION
This adds test helpers that can be used to test that a class is
using `MuchDecimal` for an attribute. This is to make the gem
friendlier to use and so users don't have to dig into the internals
of much-decimal just to test something that uses it.

The `TestHelpers` provide an `assert_decimal_as_integer` helper
method that expects a subject, attribute and options. The subject
should be an object that has mixed in `MuchDecimal` and defined
a decimal as integer attribute. The test helper will write a
decimal to the attribute and ensure the source and attribute
return the correct value.

@kellyredding - Ready for review.
